### PR TITLE
fixed memory leak

### DIFF
--- a/HEAAN/src/Scheme.cpp
+++ b/HEAAN/src/Scheme.cpp
@@ -16,6 +16,13 @@ Scheme::Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized) : ring(ring)
 	addMultKey(secretKey);
 };
 
+Scheme::~Scheme() {
+  for (auto const& t : keyMap)
+    delete t.second;
+  for (auto const& t : leftRotKeyMap)
+    delete t.second;
+}
+
 void Scheme::addEncKey(SecretKey& secretKey) {
 	ZZ* ax = new ZZ[N];
 	ZZ* bx = new ZZ[N];

--- a/HEAAN/src/Scheme.h
+++ b/HEAAN/src/Scheme.h
@@ -42,6 +42,8 @@ public:
 
 	Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized = false);
 
+	virtual ~Scheme();
+
 	//----------------------------------------------------------------------------------
 	//   KEYS GENERATION
 	//----------------------------------------------------------------------------------

--- a/HEAAN/src/StringUtils.cpp
+++ b/HEAAN/src/StringUtils.cpp
@@ -15,32 +15,36 @@
 
 void StringUtils::showVec(long* vals, long size) {
 	cout << "[";
-	for (long i = 0; i < size; ++i) {
-		cout << vals[i] << ", ";
+	cout << vals[0];
+	for (long i = 1; i < size; ++i) {
+		cout << ", " << vals[i];
 	}
 	cout << "]" << endl;
 }
 
 void StringUtils::showVec(double* vals, long size) {
 	cout << "[";
-	for (long i = 0; i < size; ++i) {
-		cout << vals[i] << ", ";
+	cout << vals[0];
+	for (long i = 1; i < size; ++i) {
+		cout << ", " << vals[i];
 	}
 	cout << "]" << endl;
 }
 
 void StringUtils::showVec(complex<double>* vals, long size) {
 	cout << "[";
-	for (long i = 0; i < size; ++i) {
-		cout << vals[i] << ", ";
+	cout << vals[0];
+	for (long i = 1; i < size; ++i) {
+		cout << ", " << vals[i];
 	}
 	cout << "]" << endl;
 }
 
 void StringUtils::showVec(ZZ* vals, long size) {
 	cout << "[";
-	for (long i = 0; i < size; ++i) {
-		cout << vals[i] << ", ";
+	cout << vals[0];
+	for (long i = 1; i < size; ++i) {
+		cout << ", " << vals[i];
 	}
 	cout << "]" << endl;
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ int main() {
   long logp = 30; ///< Scaling Factor (larger logp will give you more accurate value)
   long logn = 10; ///< number of slot is 1024 (this value should be < logN in "src/Params.h")
   long n = 1 << logn;
+  long slots = n;
   long numThread = 8;
 	
   // Construct and Generate Public Keys //


### PR DESCRIPTION
Scheme keys are not de-allocated from memory when scheme variables go out of scope. 
Added destructor to scheme to de-allocate keys and fix memory leak.
You may need to do something similar for serialized keys too, I did not look into it.

Other minor changes in this commit:
- removed trailing commas "," in vector printing functions. Before output was [1,2,3,] rather than [1,2,3]
- example code in README.md does not compile. Added undeclared "slots" variable to fix the problem.
