### PR TITLE
Resolve namespace issues

### DIFF
--- a/HEAAN/run/test.cpp
+++ b/HEAAN/run/test.cpp
@@ -8,6 +8,9 @@
 
 #include "../src/HEAAN.h"
 
+#include <string>
+
+using namespace std;
 using namespace heaan;
 
 /**

--- a/HEAAN/run/test.cpp
+++ b/HEAAN/run/test.cpp
@@ -49,10 +49,10 @@ int main(int argc, char **argv) {
 //   BOOTSTRAPPING
 //----------------------------------------------------------------------------------
 
-    logq = logp + 10; //< suppose the input ciphertext of bootstrapping has logq = logp + 10
-    logn = 3; //< larger logn will make bootstrapping tech much slower
-    long logT = 4; //< this means that we use Taylor approximation in [-1/T,1/T] with double angle fomula
-    if(string(argv[1]) == "Bootstrapping") TestScheme::testBootstrap(logq, logp, logn, logT);
+	logq = logp + 10; //< suppose the input ciphertext of bootstrapping has logq = logp + 10
+	logn = 3; //< larger logn will make bootstrapping tech much slower
+	long logT = 4; //< this means that we use Taylor approximation in [-1/T,1/T] with double angle fomula
+	if(string(argv[1]) == "Bootstrapping") TestScheme::testBootstrap(logq, logp, logn, logT);
 
 	return 0;
 }

--- a/HEAAN/run/test.cpp
+++ b/HEAAN/run/test.cpp
@@ -7,6 +7,9 @@
 */
 
 #include "../src/HEAAN.h"
+
+using namespace heaan;
+
 /**
   * This file is for test HEAAN library
   * You can find more in src/TestScheme.h
@@ -38,11 +41,11 @@ int main(int argc, char **argv) {
 	long r = 1; ///< The amout of rotation
 	if(string(argv[1]) == "RotateFast") TestScheme::testRotateFast(logq, logp, logn, r);
 	if(string(argv[1]) == "Conjugate") TestScheme::testConjugate(logq, logp, logn);
-    
+
 //----------------------------------------------------------------------------------
 //   BOOTSTRAPPING
 //----------------------------------------------------------------------------------
-    
+
     logq = logp + 10; //< suppose the input ciphertext of bootstrapping has logq = logp + 10
     logn = 3; //< larger logn will make bootstrapping tech much slower
     long logT = 4; //< this means that we use Taylor approximation in [-1/T,1/T] with double angle fomula

--- a/HEAAN/src/BootContext.cpp
+++ b/HEAAN/src/BootContext.cpp
@@ -7,7 +7,11 @@
 */
 #include "BootContext.h"
 
+namespace heaan {
+
 BootContext::BootContext(uint64_t** rpvec, uint64_t** rpvecInv, uint64_t* rp1, uint64_t* rp2,
 		long* bndvec, long* bndvecInv, long bnd1, long bnd2, long logp) :
 		rpvec(rpvec), rpvecInv(rpvecInv), rp1(rp1), rp2(rp2),
 		bndvec(bndvec), bndvecInv(bndvecInv), bnd1(bnd1), bnd2(bnd2), logp(logp){}
+
+}  // namespace heaan

--- a/HEAAN/src/BootContext.h
+++ b/HEAAN/src/BootContext.h
@@ -10,8 +10,6 @@
 
 #include <NTL/ZZ.h>
 
-using namespace NTL;
-
 namespace heaan {
 
 class BootContext {

--- a/HEAAN/src/BootContext.h
+++ b/HEAAN/src/BootContext.h
@@ -12,6 +12,8 @@
 
 using namespace NTL;
 
+namespace heaan {
+
 class BootContext {
 public:
 
@@ -31,5 +33,7 @@ public:
 			long* bndvec = NULL, long* bndvecInv = NULL, long bnd1 = 0, long bnd2 = 0, long logp = 0);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Ciphertext.cpp
+++ b/HEAAN/src/Ciphertext.cpp
@@ -9,6 +9,8 @@
 
 #include <NTL/tools.h>
 
+namespace heaan {
+
 Ciphertext::Ciphertext(long logp, long logq, long n) : logp(logp), logq(logq), n(n) {
 }
 
@@ -44,3 +46,5 @@ Ciphertext::~Ciphertext() {
 	delete[] ax;
 	delete[] bx;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/Ciphertext.cpp
+++ b/HEAAN/src/Ciphertext.cpp
@@ -9,6 +9,9 @@
 
 #include <NTL/tools.h>
 
+using namespace std;
+using namespace NTL;
+
 namespace heaan {
 
 Ciphertext::Ciphertext(long logp, long logq, long n) : logp(logp), logq(logq), n(n) {

--- a/HEAAN/src/Ciphertext.h
+++ b/HEAAN/src/Ciphertext.h
@@ -16,6 +16,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class Ciphertext {
 public:
 
@@ -38,7 +40,9 @@ public:
 	void free();
 
 	virtual ~Ciphertext();
-	
+
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Ciphertext.h
+++ b/HEAAN/src/Ciphertext.h
@@ -13,16 +13,13 @@
 #include <fstream>
 #include "Params.h"
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
 class Ciphertext {
 public:
 
-	ZZ* ax = new ZZ[N];
-	ZZ* bx = new ZZ[N];
+    NTL::ZZ* ax = new NTL::ZZ[N];
+    NTL::ZZ* bx = new NTL::ZZ[N];
 
 	long logp;
 	long logq;

--- a/HEAAN/src/Ciphertext.h
+++ b/HEAAN/src/Ciphertext.h
@@ -18,8 +18,8 @@ namespace heaan {
 class Ciphertext {
 public:
 
-    NTL::ZZ* ax = new NTL::ZZ[N];
-    NTL::ZZ* bx = new NTL::ZZ[N];
+	NTL::ZZ* ax = new NTL::ZZ[N];
+	NTL::ZZ* bx = new NTL::ZZ[N];
 
 	long logp;
 	long logq;

--- a/HEAAN/src/EvaluatorUtils.cpp
+++ b/HEAAN/src/EvaluatorUtils.cpp
@@ -12,6 +12,8 @@
 #include <cstdlib>
 
 
+namespace heaan {
+
 //----------------------------------------------------------------------------------
 //   RANDOM REAL AND COMPLEX NUMBERS
 //----------------------------------------------------------------------------------
@@ -109,3 +111,5 @@ void EvaluatorUtils::rightRotateAndEqual(complex<double>* vals, const long n, co
 	rem = (n - rem) % n;
 	leftRotateAndEqual(vals, n, rem);
 }
+
+}  // namespace heaan

--- a/HEAAN/src/EvaluatorUtils.cpp
+++ b/HEAAN/src/EvaluatorUtils.cpp
@@ -11,6 +11,8 @@
 #include <complex>
 #include <cstdlib>
 
+using namespace std;
+using namespace NTL;
 
 namespace heaan {
 

--- a/HEAAN/src/EvaluatorUtils.h
+++ b/HEAAN/src/EvaluatorUtils.h
@@ -12,9 +12,6 @@
 #include <NTL/ZZ.h>
 #include <complex>
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
 class EvaluatorUtils {
@@ -28,26 +25,26 @@ public:
 
 	static double randomReal(double bound = 1.0);
 
-	static complex<double> randomComplex(double bound = 1.0);
+	static std::complex<double> randomComplex(double bound = 1.0);
 
-	static complex<double> randomCircle(double anglebound = 1.0);
+	static std::complex<double> randomCircle(double anglebound = 1.0);
 
 	static double* randomRealArray(long size, double bound = 1.0);
 
-	static complex<double>* randomComplexArray(long size, double bound = 1.0);
+	static std::complex<double>* randomComplexArray(long size, double bound = 1.0);
 
-	static complex<double>* randomCircleArray(long size, double bound = 1.0);
+	static std::complex<double>* randomCircleArray(long size, double bound = 1.0);
 
 
 	//----------------------------------------------------------------------------------
 	//   DOUBLE & RR <-> ZZ
 	//----------------------------------------------------------------------------------
 
-	static double scaleDownToReal(const ZZ& x, const long logp);
+	static double scaleDownToReal(const NTL::ZZ& x, const long logp);
 
-	static ZZ scaleUpToZZ(const double x, const long logp);
+	static NTL::ZZ scaleUpToZZ(const double x, const long logp);
 
-	static ZZ scaleUpToZZ(const RR& x, const long logp);
+	static NTL::ZZ scaleUpToZZ(const NTL::RR& x, const long logp);
 
 
 	//----------------------------------------------------------------------------------
@@ -55,9 +52,9 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	static void leftRotateAndEqual(complex<double>* vals, const long n, const long r);
+	static void leftRotateAndEqual(std::complex<double>* vals, const long n, const long r);
 
-	static void rightRotateAndEqual(complex<double>* vals, const long n, const long r);
+	static void rightRotateAndEqual(std::complex<double>* vals, const long n, const long r);
 
 };
 

--- a/HEAAN/src/EvaluatorUtils.h
+++ b/HEAAN/src/EvaluatorUtils.h
@@ -15,6 +15,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class EvaluatorUtils {
 public:
 
@@ -58,5 +60,7 @@ public:
 	static void rightRotateAndEqual(complex<double>* vals, const long n, const long r);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/HEAAN.cpp
+++ b/HEAAN/src/HEAAN.cpp
@@ -7,6 +7,8 @@
 */
 #include "TestScheme.h"
 
+using namespace std;
+
 int main() {
 
 

--- a/HEAAN/src/HEAAN.cpp
+++ b/HEAAN/src/HEAAN.cpp
@@ -7,7 +7,7 @@
 */
 #include "TestScheme.h"
 
-using namespace std;
+using namespace heaan;
 
 int main() {
 

--- a/HEAAN/src/Key.cpp
+++ b/HEAAN/src/Key.cpp
@@ -7,6 +7,8 @@
 */
 #include "Key.h"
 
+namespace heaan {
+
 Key::Key() {
 }
 
@@ -14,3 +16,5 @@ Key::~Key() {
 	delete[] rax;
 	delete[] rbx;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/Key.h
+++ b/HEAAN/src/Key.h
@@ -11,8 +11,6 @@
 #include <NTL/ZZ.h>
 #include "Params.h"
 
-using namespace NTL;
-
 namespace heaan {
 
 class Key {

--- a/HEAAN/src/Key.h
+++ b/HEAAN/src/Key.h
@@ -13,6 +13,8 @@
 
 using namespace NTL;
 
+namespace heaan {
+
 class Key {
 public:
 
@@ -23,5 +25,7 @@ public:
 
 	virtual ~Key();
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Params.h
+++ b/HEAAN/src/Params.h
@@ -9,7 +9,6 @@
 #define HEAAN_PARAMS_H_
 
 #include <NTL/ZZ.h>
-using namespace NTL;
 
 namespace heaan {
 
@@ -30,8 +29,8 @@ static const long nprimes = (2 + logN + 4 * logQ + pbnd - 1) / pbnd;
 static const long Nnprimes = (nprimes << logN);
 static const long cbnd = (logQQ + NTL_ZZ_NBITS - 1) / NTL_ZZ_NBITS;
 static const long bignum = 0xfffffff;
-static const ZZ Q = power2_ZZ(logQ);
-static const ZZ QQ = power2_ZZ(logQQ);
+static const NTL::ZZ Q = NTL::power2_ZZ(logQ);
+static const NTL::ZZ QQ = NTL::power2_ZZ(logQQ);
 
 }  // namespace heaan
 

--- a/HEAAN/src/Params.h
+++ b/HEAAN/src/Params.h
@@ -11,6 +11,8 @@
 #include <NTL/ZZ.h>
 using namespace NTL;
 
+namespace heaan {
+
 static const long logN = 16;
 static const long logQ = 800; // 128-bit security
 
@@ -30,5 +32,7 @@ static const long cbnd = (logQQ + NTL_ZZ_NBITS - 1) / NTL_ZZ_NBITS;
 static const long bignum = 0xfffffff;
 static const ZZ Q = power2_ZZ(logQ);
 static const ZZ QQ = power2_ZZ(logQQ);
+
+}  // namespace heaan
 
 #endif /* PARAMS_H_ */

--- a/HEAAN/src/Plaintext.cpp
+++ b/HEAAN/src/Plaintext.cpp
@@ -7,6 +7,8 @@
 */
 #include "Plaintext.h"
 
+namespace heaan {
+
 Plaintext::Plaintext(long logp, long logq, long n) : logp(logp), logq(logq), n(n) {
 
 }
@@ -14,3 +16,5 @@ Plaintext::Plaintext(long logp, long logq, long n) : logp(logp), logq(logq), n(n
 Plaintext::~Plaintext() {
 	delete[] mx;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/Plaintext.h
+++ b/HEAAN/src/Plaintext.h
@@ -14,6 +14,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class Plaintext {
 public:
 
@@ -28,5 +30,7 @@ public:
 
 	virtual ~Plaintext();
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Plaintext.h
+++ b/HEAAN/src/Plaintext.h
@@ -11,15 +11,12 @@
 #include <NTL/ZZ.h>
 #include "Params.h"
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
 class Plaintext {
 public:
 
-	ZZ* mx = new ZZ[N];
+    NTL::ZZ* mx = new NTL::ZZ[N];
 
 	long logp;
 	long logq;

--- a/HEAAN/src/Plaintext.h
+++ b/HEAAN/src/Plaintext.h
@@ -16,7 +16,7 @@ namespace heaan {
 class Plaintext {
 public:
 
-    NTL::ZZ* mx = new NTL::ZZ[N];
+	NTL::ZZ* mx = new NTL::ZZ[N];
 
 	long logp;
 	long logq;

--- a/HEAAN/src/Ring.cpp
+++ b/HEAAN/src/Ring.cpp
@@ -321,7 +321,7 @@ long Ring::maxBits(const ZZ* f, long n) {
    m = 0;
 
    for (i = 0; i < n; i++) {
-      m = max(m, NumBits(f[i]));
+	  m = max(m, NumBits(f[i]));
    }
    return m;
 }
@@ -522,16 +522,16 @@ void Ring::doubleAndEqual(ZZ* p, const ZZ& mod) {
 void Ring::rightShift(ZZ* res, ZZ* p, long bits) {
 	ZZ tmp = to_ZZ(1) << (bits - 1);
 	for (long i = 0; i < N; ++i) {
-                if (p[i]>0) res[i] = (p[i] + tmp) >> bits;
-                else res[i] = (p[i] - tmp) >> bits;
+		        if (p[i]>0) res[i] = (p[i] + tmp) >> bits;
+		        else res[i] = (p[i] - tmp) >> bits;
 	}
 }
 
 void Ring::rightShiftAndEqual(ZZ* p, long bits) {
 	ZZ tmp = to_ZZ(1) << (bits - 1);
 	for (long i = 0; i < N; ++i) {
-                if (p[i]>0) p[i] += tmp;
-                else p[i] -= tmp;
+		        if (p[i]>0) p[i] += tmp;
+		        else p[i] -= tmp;
 		p[i] >>= bits;
 	}
 }

--- a/HEAAN/src/Ring.cpp
+++ b/HEAAN/src/Ring.cpp
@@ -18,6 +18,9 @@
 #include "EvaluatorUtils.h"
 #include "BootContext.h"
 
+using namespace std;
+using namespace NTL;
+
 namespace heaan {
 
 Ring::Ring() {

--- a/HEAAN/src/Ring.cpp
+++ b/HEAAN/src/Ring.cpp
@@ -18,6 +18,7 @@
 #include "EvaluatorUtils.h"
 #include "BootContext.h"
 
+namespace heaan {
 
 Ring::Ring() {
 
@@ -648,3 +649,5 @@ void Ring::sampleUniform2(ZZ* res, long bits) {
 		res[i] = RandomBits_ZZ(bits);
 	}
 }
+
+}  // namespace heaan

--- a/HEAAN/src/Ring.h
+++ b/HEAAN/src/Ring.h
@@ -15,21 +15,18 @@
 #include "BootContext.h"
 #include "RingMultiplier.h"
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
-static RR Pi = ComputePi_RR();
+static NTL::RR Pi = NTL::ComputePi_RR();
 
 class Ring {
 
 public:
 
-	ZZ* qpows;
+    NTL::ZZ* qpows;
 	long* rotGroup;
-	complex<double>* ksiPows;
-	map<long, BootContext*> bootContextMap;
+    std::complex<double>* ksiPows;
+    std::map<long, BootContext*> bootContextMap;
 	RingMultiplier multiplier;
 
 	Ring();
@@ -40,19 +37,19 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void arrayBitReverse(complex<double>* vals, long size);
+	void arrayBitReverse(std::complex<double>* vals, long size);
 
-	void EMB(complex<double>* vals, long size);
+	void EMB(std::complex<double>* vals, long size);
 
-	void EMBInvLazy(complex<double>* vals, long size);
+	void EMBInvLazy(std::complex<double>* vals, long size);
 
-	void EMBInv(complex<double>* vals, long size);
+	void EMBInv(std::complex<double>* vals, long size);
 
-	void encode(ZZ* mx, double* vals, long slots, long logp);
+	void encode(NTL::ZZ* mx, double* vals, long slots, long logp);
 
-	void encode(ZZ* mx, complex<double>* vals, long slots, long logp);
+	void encode(NTL::ZZ* mx, std::complex<double>* vals, long slots, long logp);
 
-	void decode(ZZ* mx, complex<double>* vals, long slots, long logp, long logq);
+	void decode(NTL::ZZ* mx, std::complex<double>* vals, long slots, long logp, long logq);
 
 
 	//----------------------------------------------------------------------------------
@@ -67,27 +64,27 @@ public:
 	//   MULTIPLICATION
 	//----------------------------------------------------------------------------------
 
-	long maxBits(const ZZ* f, long n);
+	long maxBits(const NTL::ZZ* f, long n);
 
-	void CRT(uint64_t* rx, ZZ* x, const long np);
+	void CRT(uint64_t* rx, NTL::ZZ* x, const long np);
 
 	void addNTTAndEqual(uint64_t* ra, uint64_t* rb, const long np);
 
-	void mult(ZZ* x, ZZ* a, ZZ* b, long np, const ZZ& q);
+	void mult(NTL::ZZ* x, NTL::ZZ* a, NTL::ZZ* b, long np, const NTL::ZZ& q);
 
-	void multNTT(ZZ* x, ZZ* a, uint64_t* rb, long np, const ZZ& q);
+	void multNTT(NTL::ZZ* x, NTL::ZZ* a, uint64_t* rb, long np, const NTL::ZZ& q);
 
-	void multDNTT(ZZ* x, uint64_t* a, uint64_t* rb, long np, const ZZ& q);
+	void multDNTT(NTL::ZZ* x, uint64_t* a, uint64_t* rb, long np, const NTL::ZZ& q);
 
-	void multAndEqual(ZZ* a, ZZ* b, long np, const ZZ& q);
+	void multAndEqual(NTL::ZZ* a, NTL::ZZ* b, long np, const NTL::ZZ& q);
 
-	void multNTTAndEqual(ZZ* a, uint64_t* rb, long np, const ZZ& q);
+	void multNTTAndEqual(NTL::ZZ* a, uint64_t* rb, long np, const NTL::ZZ& q);
 
-	void square(ZZ* x, ZZ* a, long np, const ZZ& q);
+	void square(NTL::ZZ* x, NTL::ZZ* a, long np, const NTL::ZZ& q);
 
-	void squareNTT(ZZ* x, uint64_t* ra, long np, const ZZ& q);
+	void squareNTT(NTL::ZZ* x, uint64_t* ra, long np, const NTL::ZZ& q);
 
-	void squareAndEqual(ZZ* a, long np, const ZZ& q);
+	void squareAndEqual(NTL::ZZ* a, long np, const NTL::ZZ& q);
 
 
 	//----------------------------------------------------------------------------------
@@ -95,41 +92,41 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void mod(ZZ* res, ZZ* p, const ZZ& QQ);
+	void mod(NTL::ZZ* res, NTL::ZZ* p, const NTL::ZZ& QQ);
 
-	void modAndEqual(ZZ* p, const ZZ& QQ);
+	void modAndEqual(NTL::ZZ* p, const NTL::ZZ& QQ);
 
-	void negate(ZZ* res, ZZ* p);
+	void negate(NTL::ZZ* res, NTL::ZZ* p);
 
-	void negateAndEqual(ZZ* p);
+	void negateAndEqual(NTL::ZZ* p);
 
-	void add(ZZ* res, ZZ* p1, ZZ* p2, const ZZ& QQ);
+	void add(NTL::ZZ* res, NTL::ZZ* p1, NTL::ZZ* p2, const NTL::ZZ& QQ);
 
-	void addAndEqual(ZZ* p1, ZZ* p2, const ZZ& QQ);
+	void addAndEqual(NTL::ZZ* p1, NTL::ZZ* p2, const NTL::ZZ& QQ);
 
-	void sub(ZZ* res, ZZ* p1, ZZ* p2, const ZZ& QQ);
+	void sub(NTL::ZZ* res, NTL::ZZ* p1, NTL::ZZ* p2, const NTL::ZZ& QQ);
 
-	void subAndEqual(ZZ* p1, ZZ* p2, const ZZ& QQ);
+	void subAndEqual(NTL::ZZ* p1, NTL::ZZ* p2, const NTL::ZZ& QQ);
 
-	void subAndEqual2(ZZ* p1, ZZ* p2, const ZZ& QQ);
+	void subAndEqual2(NTL::ZZ* p1, NTL::ZZ* p2, const NTL::ZZ& QQ);
 
-	void multByMonomial(ZZ* res, ZZ* p, long mDeg);
+	void multByMonomial(NTL::ZZ* res, NTL::ZZ* p, long mDeg);
 
-	void multByMonomialAndEqual(ZZ* p, long mDeg);
+	void multByMonomialAndEqual(NTL::ZZ* p, long mDeg);
 
-	void multByConst(ZZ* res, ZZ* p, ZZ& cnst, const ZZ& QQ);
+	void multByConst(NTL::ZZ* res, NTL::ZZ* p, NTL::ZZ& cnst, const NTL::ZZ& QQ);
 
-	void multByConstAndEqual(ZZ* p, ZZ& cnst, const ZZ& QQ);
+	void multByConstAndEqual(NTL::ZZ* p, NTL::ZZ& cnst, const NTL::ZZ& QQ);
 
-	void leftShift(ZZ* res, ZZ* p, const long bits, const ZZ& QQ);
+	void leftShift(NTL::ZZ* res, NTL::ZZ* p, const long bits, const NTL::ZZ& QQ);
 
-	void leftShiftAndEqual(ZZ* p, const long bits, const ZZ& QQ);
+	void leftShiftAndEqual(NTL::ZZ* p, const long bits, const NTL::ZZ& QQ);
 
-	void doubleAndEqual(ZZ* p, const ZZ& QQ);
+	void doubleAndEqual(NTL::ZZ* p, const NTL::ZZ& QQ);
 
-	void rightShift(ZZ* res, ZZ* p, long bits);
+	void rightShift(NTL::ZZ* res, NTL::ZZ* p, long bits);
 
-	void rightShiftAndEqual(ZZ* p, long bits);
+	void rightShiftAndEqual(NTL::ZZ* p, long bits);
 
 
 	//----------------------------------------------------------------------------------
@@ -137,9 +134,9 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void leftRotate(ZZ* res, ZZ* p, long r);
+	void leftRotate(NTL::ZZ* res, NTL::ZZ* p, long r);
 
-	void conjugate(ZZ* res, ZZ* p);
+	void conjugate(NTL::ZZ* res, NTL::ZZ* p);
 
 
 	//----------------------------------------------------------------------------------
@@ -147,19 +144,19 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void subFromGaussAndEqual(ZZ* res, const ZZ& q);
-	
-	void subFromGaussAndEqual(ZZ* res, const ZZ& q, double _sigma);
+	void subFromGaussAndEqual(NTL::ZZ* res, const NTL::ZZ& q);
 
-	void addGaussAndEqual(ZZ* res, const ZZ& q);
-	
-	void addGaussAndEqual(ZZ* res, const ZZ& q, double _sigma);
+	void subFromGaussAndEqual(NTL::ZZ* res, const NTL::ZZ& q, double _sigma);
 
-	void sampleHWT(ZZ* res);
+	void addGaussAndEqual(NTL::ZZ* res, const NTL::ZZ& q);
 
-	void sampleZO(ZZ* res);
+	void addGaussAndEqual(NTL::ZZ* res, const NTL::ZZ& q, double _sigma);
 
-	void sampleUniform2(ZZ* res, long bits);
+	void sampleHWT(NTL::ZZ* res);
+
+	void sampleZO(NTL::ZZ* res);
+
+	void sampleUniform2(NTL::ZZ* res, long bits);
 
 
 	//----------------------------------------------------------------------------------
@@ -167,11 +164,11 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void DFT(complex<double>* vals, long n);
+	void DFT(std::complex<double>* vals, long n);
 
-	void IDFTLazy(complex<double>* vals, long n);
+	void IDFTLazy(std::complex<double>* vals, long n);
 
-	void IDFT(complex<double>* vals, long n);
+	void IDFT(std::complex<double>* vals, long n);
 
 };
 

--- a/HEAAN/src/Ring.h
+++ b/HEAAN/src/Ring.h
@@ -18,6 +18,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 static RR Pi = ComputePi_RR();
 
 class Ring {
@@ -172,5 +174,7 @@ public:
 	void IDFT(complex<double>* vals, long n);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Ring.h
+++ b/HEAAN/src/Ring.h
@@ -23,10 +23,10 @@ class Ring {
 
 public:
 
-    NTL::ZZ* qpows;
+	NTL::ZZ* qpows;
 	long* rotGroup;
-    std::complex<double>* ksiPows;
-    std::map<long, BootContext*> bootContextMap;
+	std::complex<double>* ksiPows;
+	std::map<long, BootContext*> bootContextMap;
 	RingMultiplier multiplier;
 
 	Ring();

--- a/HEAAN/src/RingMultiplier.cpp
+++ b/HEAAN/src/RingMultiplier.cpp
@@ -94,7 +94,7 @@ bool RingMultiplier::primeTest(uint64_t p) {
 		uint64_t mod = powMod(temp1,temp2,p);
 		while (temp2 != p - 1 && mod != 1 && mod != p - 1) {
 			mulMod(mod, mod, mod, p);
-		    temp2 *= 2;
+			temp2 *= 2;
 		}
 		if (mod != p - 1 && temp2 % 2 == 0) return false;
 	}
@@ -554,16 +554,16 @@ uint64_t RingMultiplier::findPrimitiveRoot(uint64_t modulus) {
 }
 
 uint64_t RingMultiplier::findMthRootOfUnity(uint64_t M, uint64_t mod) {
-    uint64_t res;
-    res = findPrimitiveRoot(mod);
-    if((mod - 1) % M == 0) {
-        uint64_t factor = (mod - 1) / M;
-        res = powMod(res, factor, mod);
-        return res;
-    }
-    else {
-        return -1;
-    }
+	uint64_t res;
+	res = findPrimitiveRoot(mod);
+	if((mod - 1) % M == 0) {
+		uint64_t factor = (mod - 1) / M;
+		res = powMod(res, factor, mod);
+		return res;
+	}
+	else {
+		return -1;
+	}
 }
 
 }  // namespace heaan

--- a/HEAAN/src/RingMultiplier.cpp
+++ b/HEAAN/src/RingMultiplier.cpp
@@ -14,6 +14,9 @@
 #include <cstdlib>
 #include <iterator>
 
+using namespace std;
+using namespace NTL;
+
 namespace heaan {
 
 RingMultiplier::RingMultiplier() {

--- a/HEAAN/src/RingMultiplier.cpp
+++ b/HEAAN/src/RingMultiplier.cpp
@@ -14,6 +14,8 @@
 #include <cstdlib>
 #include <iterator>
 
+namespace heaan {
+
 RingMultiplier::RingMultiplier() {
 
 	uint64_t primetest = (1ULL << pbnd) + 1;
@@ -561,4 +563,4 @@ uint64_t RingMultiplier::findMthRootOfUnity(uint64_t M, uint64_t mod) {
     }
 }
 
-
+}  // namespace heaan

--- a/HEAAN/src/RingMultiplier.h
+++ b/HEAAN/src/RingMultiplier.h
@@ -13,9 +13,6 @@
 #include <NTL/ZZ.h>
 #include "Params.h"
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
 class RingMultiplier {
@@ -28,11 +25,11 @@ public:
 	uint64_t** scaledRootInvPows = new uint64_t*[nprimes];
 	uint64_t* scaledNInv = new uint64_t[nprimes];
 	_ntl_general_rem_one_struct* red_ss_array[nprimes];
-	mulmod_precon_t* coeffpinv_array[nprimes];
+    NTL::mulmod_precon_t* coeffpinv_array[nprimes];
 
-	ZZ* pProd = new ZZ[nprimes];
-	ZZ* pProdh = new ZZ[nprimes];
-	ZZ** pHat = new ZZ*[nprimes];
+    NTL::ZZ* pProd = new NTL::ZZ[nprimes];
+    NTL::ZZ* pProdh = new NTL::ZZ[nprimes];
+    NTL::ZZ** pHat = new NTL::ZZ*[nprimes];
 	uint64_t** pHatInvModp = new uint64_t*[nprimes];
 
 	RingMultiplier();
@@ -42,27 +39,27 @@ public:
 	void NTT(uint64_t* a, long index);
 	void INTT(uint64_t* a, long index);
 
-	void CRT(uint64_t* rx, ZZ* x, const long np);
+	void CRT(uint64_t* rx, NTL::ZZ* x, const long np);
 
 	void addNTTAndEqual(uint64_t* ra, uint64_t* rb, const long np);
 
-	void reconstruct(ZZ* x, uint64_t* rx, long np, const ZZ& QQ);
+	void reconstruct(NTL::ZZ* x, uint64_t* rx, long np, const NTL::ZZ& QQ);
 
-	void mult(ZZ* x, ZZ* a, ZZ* b, long np, const ZZ& QQ);
+	void mult(NTL::ZZ* x, NTL::ZZ* a, NTL::ZZ* b, long np, const NTL::ZZ& QQ);
 
-	void multNTT(ZZ* x, ZZ* a, uint64_t* rb, long np, const ZZ& QQ);
+	void multNTT(NTL::ZZ* x, NTL::ZZ* a, uint64_t* rb, long np, const NTL::ZZ& QQ);
 
-	void multDNTT(ZZ* x, uint64_t* ra, uint64_t* rb, long np, const ZZ& QQ);
+	void multDNTT(NTL::ZZ* x, uint64_t* ra, uint64_t* rb, long np, const NTL::ZZ& QQ);
 
-	void multAndEqual(ZZ* a, ZZ* b, long np, const ZZ& QQ);
+	void multAndEqual(NTL::ZZ* a, NTL::ZZ* b, long np, const NTL::ZZ& QQ);
 
-	void multNTTAndEqual(ZZ* a, uint64_t* rb, long np, const ZZ& QQ);
+	void multNTTAndEqual(NTL::ZZ* a, uint64_t* rb, long np, const NTL::ZZ& QQ);
 
-	void square(ZZ* x, ZZ* a, long np, const ZZ& QQ);
+	void square(NTL::ZZ* x, NTL::ZZ* a, long np, const NTL::ZZ& QQ);
 
-	void squareNTT(ZZ* x, uint64_t* ra, long np, const ZZ& QQ);
+	void squareNTT(NTL::ZZ* x, uint64_t* ra, long np, const NTL::ZZ& QQ);
 
-	void squareAndEqual(ZZ* a, long np, const ZZ& QQ);
+	void squareAndEqual(NTL::ZZ* a, long np, const NTL::ZZ& QQ);
 
 	void mulMod(uint64_t& r, uint64_t a, uint64_t b, uint64_t p);
 
@@ -81,7 +78,7 @@ public:
 
 	uint32_t bitReverse(uint32_t x);
 
-	void findPrimeFactors(vector<uint64_t> &s, uint64_t number);
+	void findPrimeFactors(std::vector<uint64_t> &s, uint64_t number);
 
 	uint64_t findPrimitiveRoot(uint64_t m);
 

--- a/HEAAN/src/RingMultiplier.h
+++ b/HEAAN/src/RingMultiplier.h
@@ -16,6 +16,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class RingMultiplier {
 public:
 
@@ -86,5 +88,7 @@ public:
 	uint64_t findMthRootOfUnity(uint64_t M, uint64_t p);
 
 };
+
+}  // namespace heaan
 
 #endif /* RINGMULTIPLIER_H_ */

--- a/HEAAN/src/RingMultiplier.h
+++ b/HEAAN/src/RingMultiplier.h
@@ -25,11 +25,11 @@ public:
 	uint64_t** scaledRootInvPows = new uint64_t*[nprimes];
 	uint64_t* scaledNInv = new uint64_t[nprimes];
 	_ntl_general_rem_one_struct* red_ss_array[nprimes];
-    NTL::mulmod_precon_t* coeffpinv_array[nprimes];
+	NTL::mulmod_precon_t* coeffpinv_array[nprimes];
 
-    NTL::ZZ* pProd = new NTL::ZZ[nprimes];
-    NTL::ZZ* pProdh = new NTL::ZZ[nprimes];
-    NTL::ZZ** pHat = new NTL::ZZ*[nprimes];
+	NTL::ZZ* pProd = new NTL::ZZ[nprimes];
+	NTL::ZZ* pProdh = new NTL::ZZ[nprimes];
+	NTL::ZZ** pHat = new NTL::ZZ*[nprimes];
 	uint64_t** pHatInvModp = new uint64_t*[nprimes];
 
 	RingMultiplier();

--- a/HEAAN/src/Scheme.cpp
+++ b/HEAAN/src/Scheme.cpp
@@ -25,9 +25,9 @@ Scheme::Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized) : ring(ring)
 
 Scheme::~Scheme() {
   for (auto const& t : keyMap)
-    delete t.second;
+	delete t.second;
   for (auto const& t : leftRotKeyMap)
-    delete t.second;
+	delete t.second;
 }
 
 void Scheme::addEncKey(SecretKey& secretKey) {

--- a/HEAAN/src/Scheme.cpp
+++ b/HEAAN/src/Scheme.cpp
@@ -11,6 +11,8 @@
 #include "StringUtils.h"
 #include "SerializationUtils.h"
 
+namespace heaan {
+
 Scheme::Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized) : ring(ring), isSerialized(isSerialized) {
 	addEncKey(secretKey);
 	addMultKey(secretKey);
@@ -1276,3 +1278,5 @@ void Scheme::bootstrapAndEqual(Ciphertext& cipher, long logq, long logQ, long lo
 
 	cipher.logp = logp;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/Scheme.cpp
+++ b/HEAAN/src/Scheme.cpp
@@ -8,8 +8,13 @@
 #include "Scheme.h"
 
 #include "NTL/BasicThreadPool.h"
+#include <string>
+
 #include "StringUtils.h"
 #include "SerializationUtils.h"
+
+using namespace std;
+using namespace NTL;
 
 namespace heaan {
 

--- a/HEAAN/src/Scheme.h
+++ b/HEAAN/src/Scheme.h
@@ -34,11 +34,11 @@ public:
 
 	bool isSerialized;
 
-    std::map<long, Key*> keyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
-    std::map<long, Key*> leftRotKeyMap; ///< contain left rotation keys, if generated
+	std::map<long, Key*> keyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
+	std::map<long, Key*> leftRotKeyMap; ///< contain left rotation keys, if generated
 
-    std::map<long, std::string> serKeyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
-    std::map<long, std::string> serLeftRotKeyMap; ///< contain left rotation keys, if generated
+	std::map<long, std::string> serKeyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
+	std::map<long, std::string> serLeftRotKeyMap; ///< contain left rotation keys, if generated
 
 	Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized = false);
 
@@ -75,13 +75,13 @@ public:
 
 	void encode(Plaintext& plain, double* vals, long n, long logp, long logq);
 
-    std::complex<double>* decode(Plaintext& plain);
+	std::complex<double>* decode(Plaintext& plain);
 
 	void encodeSingle(Plaintext& plain, std::complex<double> val, long logp, long logq);
 
 	void encodeSingle(Plaintext& plain, double val, long logp, long logq);
 
-    std::complex<double> decodeSingle(Plaintext& plain);
+	std::complex<double> decodeSingle(Plaintext& plain);
 
 
 	//----------------------------------------------------------------------------------
@@ -103,15 +103,15 @@ public:
 
 	void encryptZeros(Ciphertext& cipher, long n, long logp, long logq);
 
-    std::complex<double>* decrypt(SecretKey& secretKey, Ciphertext& cipher);
+	std::complex<double>* decrypt(SecretKey& secretKey, Ciphertext& cipher);
 
-    std::complex<double>* decryptForShare(SecretKey& secretKey, Ciphertext& cipher, long=0);
+	std::complex<double>* decryptForShare(SecretKey& secretKey, Ciphertext& cipher, long=0);
 
 	void encryptSingle(Ciphertext& cipher, std::complex<double> val, long logp, long logq);
 
 	void encryptSingle(Ciphertext& cipher, double val, long logp, long logq);
 
-    std::complex<double> decryptSingle(SecretKey& secretKey, Ciphertext& cipher);
+	std::complex<double> decryptSingle(SecretKey& secretKey, Ciphertext& cipher);
 
 
 	//----------------------------------------------------------------------------------

--- a/HEAAN/src/Scheme.h
+++ b/HEAAN/src/Scheme.h
@@ -23,6 +23,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 static long ENCRYPTION = 0;
 static long MULTIPLICATION  = 1;
 static long CONJUGATION = 2;
@@ -251,5 +253,7 @@ public:
 
 	void bootstrapAndEqual(Ciphertext& cipher, long logq, long logQ, long logT, long logI = 4);
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/Scheme.h
+++ b/HEAAN/src/Scheme.h
@@ -11,6 +11,7 @@
 #include <NTL/RR.h>
 #include <NTL/ZZ.h>
 #include <complex>
+#include <string>
 
 #include "BootContext.h"
 #include "SecretKey.h"
@@ -19,9 +20,6 @@
 #include "Key.h"
 #include "EvaluatorUtils.h"
 #include "Ring.h"
-
-using namespace std;
-using namespace NTL;
 
 namespace heaan {
 
@@ -36,11 +34,11 @@ public:
 
 	bool isSerialized;
 
-	map<long, Key*> keyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
-	map<long, Key*> leftRotKeyMap; ///< contain left rotation keys, if generated
+    std::map<long, Key*> keyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
+    std::map<long, Key*> leftRotKeyMap; ///< contain left rotation keys, if generated
 
-	map<long, string> serKeyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
-	map<long, string> serLeftRotKeyMap; ///< contain left rotation keys, if generated
+    std::map<long, std::string> serKeyMap; ///< contain Encryption, Multiplication and Conjugation keys, if generated
+    std::map<long, std::string> serLeftRotKeyMap; ///< contain left rotation keys, if generated
 
 	Scheme(SecretKey& secretKey, Ring& ring, bool isSerialized = false);
 
@@ -73,17 +71,17 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	void encode(Plaintext& plain, complex<double>* vals, long n, long logp, long logq);
+	void encode(Plaintext& plain, std::complex<double>* vals, long n, long logp, long logq);
 
 	void encode(Plaintext& plain, double* vals, long n, long logp, long logq);
 
-	complex<double>* decode(Plaintext& plain);
+    std::complex<double>* decode(Plaintext& plain);
 
-	void encodeSingle(Plaintext& plain, complex<double> val, long logp, long logq);
+	void encodeSingle(Plaintext& plain, std::complex<double> val, long logp, long logq);
 
 	void encodeSingle(Plaintext& plain, double val, long logp, long logq);
 
-	complex<double> decodeSingle(Plaintext& plain);
+    std::complex<double> decodeSingle(Plaintext& plain);
 
 
 	//----------------------------------------------------------------------------------
@@ -95,25 +93,25 @@ public:
 
 	void decryptMsg(Plaintext& plain, SecretKey& secretKey, Ciphertext& cipher);
 
-	void encrypt(Ciphertext& cipher, complex<double>* vals, long n, long logp, long logq);
+	void encrypt(Ciphertext& cipher, std::complex<double>* vals, long n, long logp, long logq);
 
 	void encrypt(Ciphertext& cipher, double* vals, long n, long logp, long logq);
-	
-	void encryptBySk(Ciphertext& cipher, SecretKey& secretKey, complex<double>* vals, long n, long logp, long logq, double=3.2);
-	
+
+	void encryptBySk(Ciphertext& cipher, SecretKey& secretKey, std::complex<double>* vals, long n, long logp, long logq, double=3.2);
+
 	void encryptBySk(Ciphertext& cipher, SecretKey& secretKey, double* vals, long n, long logp, long logq, double=3.2);
 
 	void encryptZeros(Ciphertext& cipher, long n, long logp, long logq);
 
-	complex<double>* decrypt(SecretKey& secretKey, Ciphertext& cipher);
-	
-	complex<double>* decryptForShare(SecretKey& secretKey, Ciphertext& cipher, long=0);
+    std::complex<double>* decrypt(SecretKey& secretKey, Ciphertext& cipher);
 
-	void encryptSingle(Ciphertext& cipher, complex<double> val, long logp, long logq);
+    std::complex<double>* decryptForShare(SecretKey& secretKey, Ciphertext& cipher, long=0);
+
+	void encryptSingle(Ciphertext& cipher, std::complex<double> val, long logp, long logq);
 
 	void encryptSingle(Ciphertext& cipher, double val, long logp, long logq);
 
-	complex<double> decryptSingle(SecretKey& secretKey, Ciphertext& cipher);
+    std::complex<double> decryptSingle(SecretKey& secretKey, Ciphertext& cipher);
 
 
 	//----------------------------------------------------------------------------------
@@ -130,15 +128,15 @@ public:
 
 	void addConst(Ciphertext& res, Ciphertext& cipher, double cnst, long logp);
 
-	void addConst(Ciphertext& res, Ciphertext& cipher, RR& cnst, long logp);
+	void addConst(Ciphertext& res, Ciphertext& cipher, NTL::RR& cnst, long logp);
 
-	void addConst(Ciphertext& res, Ciphertext& cipher, complex<double> cnst, long logp);
+	void addConst(Ciphertext& res, Ciphertext& cipher, std::complex<double> cnst, long logp);
 
 	void addConstAndEqual(Ciphertext& cipher, double cnst, long logp);
 
-	void addConstAndEqual(Ciphertext& cipher, RR& cnst, long logp);
+	void addConstAndEqual(Ciphertext& cipher, NTL::RR& cnst, long logp);
 
-	void addConstAndEqual(Ciphertext& cipher, complex<double> cnst, long logp);
+	void addConstAndEqual(Ciphertext& cipher, std::complex<double> cnst, long logp);
 
 	void sub(Ciphertext& res, Ciphertext& cipher1, Ciphertext& cipher2);
 
@@ -164,23 +162,23 @@ public:
 
 	void multByConst(Ciphertext& res, Ciphertext& cipher, double cnst, long logp);
 
-	void multByConst(Ciphertext& res, Ciphertext& cipher, complex<double> cnst, long logp);
+	void multByConst(Ciphertext& res, Ciphertext& cipher, std::complex<double> cnst, long logp);
 
-	void multByConstVec(Ciphertext& res, Ciphertext& cipher, complex<double>* cnstVec, long logp);
+	void multByConstVec(Ciphertext& res, Ciphertext& cipher, std::complex<double>* cnstVec, long logp);
 
-	void multByConstVecAndEqual(Ciphertext& cipher, complex<double>* cnstVec, long logp);
+	void multByConstVecAndEqual(Ciphertext& cipher, std::complex<double>* cnstVec, long logp);
 
 	void multByConstAndEqual(Ciphertext& cipher, double cnst, long logp);
 
-	void multByConstAndEqual(Ciphertext& cipher, RR& cnst, long logp);
+	void multByConstAndEqual(Ciphertext& cipher, NTL::RR& cnst, long logp);
 
-	void multByConstAndEqual(Ciphertext& cipher, complex<double> cnst, long logp);
+	void multByConstAndEqual(Ciphertext& cipher, std::complex<double> cnst, long logp);
 
-	void multByPoly(Ciphertext& res, Ciphertext& cipher, ZZ* poly, long logp);
+	void multByPoly(Ciphertext& res, Ciphertext& cipher, NTL::ZZ* poly, long logp);
 
 	void multByPolyNTT(Ciphertext& res, Ciphertext& cipher, uint64_t* rpoly, long bnd, long logp);
 
-	void multByPolyAndEqual(Ciphertext& cipher, ZZ* poly, long logp);
+	void multByPolyAndEqual(Ciphertext& cipher, NTL::ZZ* poly, long logp);
 
 	void multByPolyNTTAndEqual(Ciphertext& cipher, uint64_t* rpoly, long bnd, long logp);
 

--- a/HEAAN/src/SchemeAlgo.cpp
+++ b/HEAAN/src/SchemeAlgo.cpp
@@ -7,6 +7,10 @@
 */
 #include "SchemeAlgo.h"
 
+using namespace std;
+using namespace NTL;
+
+namespace heaan {
 
 void SchemeAlgo::powerOf2(Ciphertext& res, Ciphertext& cipher, long logp, long logDegree) {
 	res.copy(cipher);
@@ -137,3 +141,5 @@ void SchemeAlgo::functionLazy(Ciphertext& res, Ciphertext& cipher, string& funcN
 	}
 	delete[] cpows;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/SchemeAlgo.h
+++ b/HEAAN/src/SchemeAlgo.h
@@ -27,7 +27,7 @@ static std::string SIGMOID   = "Sigmoid"; ///< sigmoid(x) = exp(x) / (1 + exp(x)
 class SchemeAlgo {
 public:
 	Scheme& scheme;
-    std::map<std::string, double*> taylorCoeffsMap;
+	std::map<std::string, double*> taylorCoeffsMap;
 
 	SchemeAlgo(Scheme& scheme) : scheme(scheme) {
 		taylorCoeffsMap.insert(std::pair<std::string, double*>(LOGARITHM,new double[11] {0,1,-0.5,1./3,-1./4,1./5,-1./6,1./7,-1./8,1./9,-1./10}));

--- a/HEAAN/src/SchemeAlgo.h
+++ b/HEAAN/src/SchemeAlgo.h
@@ -17,6 +17,8 @@
 #include "Ciphertext.h"
 #include "Scheme.h"
 
+namespace heaan {
+
 static string LOGARITHM = "Logarithm"; ///< log(x)
 static string EXPONENT  = "Exponent"; ///< exp(x)
 static string SIGMOID   = "Sigmoid"; ///< sigmoid(x) = exp(x) / (1 + exp(x))
@@ -48,5 +50,7 @@ public:
 	void functionLazy(Ciphertext& res, Ciphertext& cipher, string& funcName, long logp, long degree);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/SchemeAlgo.h
+++ b/HEAAN/src/SchemeAlgo.h
@@ -10,6 +10,7 @@
 
 #include <NTL/BasicThreadPool.h>
 #include <NTL/ZZ.h>
+#include <string>
 
 #include "EvaluatorUtils.h"
 #include "Plaintext.h"
@@ -19,19 +20,19 @@
 
 namespace heaan {
 
-static string LOGARITHM = "Logarithm"; ///< log(x)
-static string EXPONENT  = "Exponent"; ///< exp(x)
-static string SIGMOID   = "Sigmoid"; ///< sigmoid(x) = exp(x) / (1 + exp(x))
+static std::string LOGARITHM = "Logarithm"; ///< log(x)
+static std::string EXPONENT  = "Exponent"; ///< exp(x)
+static std::string SIGMOID   = "Sigmoid"; ///< sigmoid(x) = exp(x) / (1 + exp(x))
 
 class SchemeAlgo {
 public:
 	Scheme& scheme;
-	map<string, double*> taylorCoeffsMap;
+    std::map<std::string, double*> taylorCoeffsMap;
 
 	SchemeAlgo(Scheme& scheme) : scheme(scheme) {
-		taylorCoeffsMap.insert(pair<string, double*>(LOGARITHM,new double[11] {0,1,-0.5,1./3,-1./4,1./5,-1./6,1./7,-1./8,1./9,-1./10}));
-		taylorCoeffsMap.insert(pair<string, double*>(EXPONENT,new double[11] {1,1,0.5,1./6,1./24,1./120,1./720,1./5040,1./40320,1./362880,1./3628800 }));
-		taylorCoeffsMap.insert(pair<string, double*>(SIGMOID,new double[11] {1./2,1./4,0,-1./48,0,1./480,0,-17./80640,0,31./1451520,0}));
+		taylorCoeffsMap.insert(std::pair<std::string, double*>(LOGARITHM,new double[11] {0,1,-0.5,1./3,-1./4,1./5,-1./6,1./7,-1./8,1./9,-1./10}));
+		taylorCoeffsMap.insert(std::pair<std::string, double*>(EXPONENT,new double[11] {1,1,0.5,1./6,1./24,1./120,1./720,1./5040,1./40320,1./362880,1./3628800 }));
+		taylorCoeffsMap.insert(std::pair<std::string, double*>(SIGMOID,new double[11] {1./2,1./4,0,-1./48,0,1./480,0,-17./80640,0,31./1451520,0}));
 	};
 
 
@@ -45,9 +46,9 @@ public:
 
 	void inverse(Ciphertext& res, Ciphertext& cipher, long logp, long steps);
 
-	void function(Ciphertext& res, Ciphertext& cipher, string& funcName, long logp, long degree);
+	void function(Ciphertext& res, Ciphertext& cipher, std::string& funcName, long logp, long degree);
 
-	void functionLazy(Ciphertext& res, Ciphertext& cipher, string& funcName, long logp, long degree);
+	void functionLazy(Ciphertext& res, Ciphertext& cipher, std::string& funcName, long logp, long degree);
 
 };
 

--- a/HEAAN/src/SecretKey.cpp
+++ b/HEAAN/src/SecretKey.cpp
@@ -7,6 +7,10 @@
 */
 #include "SecretKey.h"
 
+namespace heaan {
+
 SecretKey::SecretKey(Ring& ring) {
 	ring.sampleHWT(sx);
 }
+
+}  // namespace heaan

--- a/HEAAN/src/SecretKey.h
+++ b/HEAAN/src/SecretKey.h
@@ -12,15 +12,12 @@
 
 #include "Ring.h"
 
-using namespace std;
-using namespace NTL;
-
 namespace heaan {
 
 class SecretKey {
 public:
 
-	ZZ* sx = new ZZ[N];
+    NTL::ZZ* sx = new NTL::ZZ[N];
 
 	SecretKey(Ring& ring);
 

--- a/HEAAN/src/SecretKey.h
+++ b/HEAAN/src/SecretKey.h
@@ -15,6 +15,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class SecretKey {
 public:
 
@@ -23,5 +25,7 @@ public:
 	SecretKey(Ring& ring);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/SecretKey.h
+++ b/HEAAN/src/SecretKey.h
@@ -17,7 +17,7 @@ namespace heaan {
 class SecretKey {
 public:
 
-    NTL::ZZ* sx = new NTL::ZZ[N];
+	NTL::ZZ* sx = new NTL::ZZ[N];
 
 	SecretKey(Ring& ring);
 

--- a/HEAAN/src/SerializationUtils.cpp
+++ b/HEAAN/src/SerializationUtils.cpp
@@ -7,6 +7,11 @@
 */
 #include "SerializationUtils.h"
 
+using namespace std;
+using namespace NTL;
+
+namespace heaan {
+
 void SerializationUtils::writeCiphertext(Ciphertext& cipher, string path) {
 	fstream fout;
 	fout.open(path, ios::binary|ios::out);
@@ -74,3 +79,4 @@ Key* SerializationUtils::readKey(string path) {
 	return &key;
 }
 
+}  // namespace heaan

--- a/HEAAN/src/SerializationUtils.h
+++ b/HEAAN/src/SerializationUtils.h
@@ -17,6 +17,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class SerializationUtils {
 public:
 
@@ -26,5 +28,7 @@ public:
 	static void writeKey(Key* key, string path);
 	static Key* readKey(string path);
 };
+
+}  // namespace heaan
 
 #endif /* SERIALIZATIONUTILS_H_ */

--- a/HEAAN/src/SerializationUtils.h
+++ b/HEAAN/src/SerializationUtils.h
@@ -9,24 +9,22 @@
 #define HEAAN_SERIALIZATIONUTILS_H_
 
 #include <iostream>
+#include <string>
 
 #include "Ciphertext.h"
 #include "Params.h"
 #include "Key.h"
-
-using namespace std;
-using namespace NTL;
 
 namespace heaan {
 
 class SerializationUtils {
 public:
 
-	static void writeCiphertext(Ciphertext& ciphertext, string path);
-	static Ciphertext* readCiphertext(string path);
+	static void writeCiphertext(Ciphertext& ciphertext, std::string path);
+	static Ciphertext* readCiphertext(std::string path);
 
-	static void writeKey(Key* key, string path);
-	static Key* readKey(string path);
+	static void writeKey(Key* key, std::string path);
+	static Key* readKey(std::string path);
 };
 
 }  // namespace heaan

--- a/HEAAN/src/StringUtils.cpp
+++ b/HEAAN/src/StringUtils.cpp
@@ -7,6 +7,7 @@
 */
 #include "StringUtils.h"
 
+using namespace std;
 
 namespace heaan {
 
@@ -42,7 +43,7 @@ void StringUtils::showVec(complex<double>* vals, long size) {
 	cout << "]" << endl;
 }
 
-void StringUtils::showVec(ZZ* vals, long size) {
+void StringUtils::showVec(NTL::ZZ* vals, long size) {
 	cout << "[";
 	cout << vals[0];
 	for (long i = 1; i < size; ++i) {

--- a/HEAAN/src/StringUtils.cpp
+++ b/HEAAN/src/StringUtils.cpp
@@ -8,6 +8,8 @@
 #include "StringUtils.h"
 
 
+namespace heaan {
+
 //----------------------------------------------------------------------------------
 //   SHOW ARRAY
 //----------------------------------------------------------------------------------
@@ -131,3 +133,5 @@ void StringUtils::compare(complex<double> val1, complex<double>* vals2, long siz
 		cout << "---------------------" << endl;
 	}
 }
+
+}  // namespace heaan

--- a/HEAAN/src/StringUtils.h
+++ b/HEAAN/src/StringUtils.h
@@ -15,6 +15,8 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
+
 class StringUtils {
 public:
 
@@ -55,5 +57,7 @@ public:
 	static void compare(complex<double> val1, complex<double>* vals2, long size, string prefix);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/StringUtils.h
+++ b/HEAAN/src/StringUtils.h
@@ -11,9 +11,7 @@
 #include <NTL/ZZ.h>
 
 #include <complex>
-
-using namespace std;
-using namespace NTL;
+#include <string>
 
 namespace heaan {
 
@@ -30,9 +28,9 @@ public:
 
 	static void showVec(double* vals, long size);
 
-	static void showVec(complex<double>* vals, long size);
+	static void showVec(std::complex<double>* vals, long size);
 
-	static void showVec(ZZ* vals, long size);
+	static void showVec(NTL::ZZ* vals, long size);
 
 
 	//----------------------------------------------------------------------------------
@@ -40,21 +38,21 @@ public:
 	//----------------------------------------------------------------------------------
 
 
-	static void compare(double val1, double val2, string prefix);
+	static void compare(double val1, double val2, std::string prefix);
 
-	static void compare(complex<double> val1, complex<double> val2, string prefix);
+	static void compare(std::complex<double> val1, std::complex<double> val2, std::string prefix);
 
-	static void compare(double* vals1, double* vals2, long size, string prefix);
+	static void compare(double* vals1, double* vals2, long size, std::string prefix);
 
-	static void compare(complex<double>* vals1, complex<double>* vals2, long size, string prefix);
+	static void compare(std::complex<double>* vals1, std::complex<double>* vals2, long size, std::string prefix);
 
-	static void compare(double* vals1, double val2, long size, string prefix);
+	static void compare(double* vals1, double val2, long size, std::string prefix);
 
-	static void compare(complex<double>* vals1, complex<double> val2, long size, string prefix);
+	static void compare(std::complex<double>* vals1, std::complex<double> val2, long size, std::string prefix);
 
-	static void compare(double val1, double* vals2, long size, string prefix);
+	static void compare(double val1, double* vals2, long size, std::string prefix);
 
-	static void compare(complex<double> val1, complex<double>* vals2, long size, string prefix);
+	static void compare(std::complex<double> val1, std::complex<double>* vals2, long size, std::string prefix);
 
 };
 

--- a/HEAAN/src/TestScheme.cpp
+++ b/HEAAN/src/TestScheme.cpp
@@ -23,6 +23,7 @@
 using namespace std;
 using namespace NTL;
 
+namespace heaan {
 
 //----------------------------------------------------------------------------------
 //   STANDARD TESTS
@@ -83,9 +84,9 @@ void TestScheme::testEncryptBySk(long logq, long logp, long logn) {
 
 void TestScheme::testDecryptForShare(long logq, long logp, long logn, long logErrorBound) {
 	cout << "!!! START TEST Decrypt for Share !!!" << endl;
-	
+
 	double sigma1 = 3.2 * sqrt(2);
-	
+
 	cout << "Note : encryption std is changed to sigma1 = " << sigma1 << endl;
 	srand(time(NULL));
 	SetNumThreads(8);
@@ -691,3 +692,5 @@ void TestScheme::testBootstrapSingleReal(long logq, long logp, long logT) {
 
 	cout << "!!! END TEST BOOTSRTAP SINGLE REAL !!!" << endl;
 }
+
+}  // namespace heaan

--- a/HEAAN/src/TestScheme.h
+++ b/HEAAN/src/TestScheme.h
@@ -8,6 +8,8 @@
 #ifndef HEAAN_TESTSCHEME_H_
 #define HEAAN_TESTSCHEME_H_
 
+namespace heaan {
+
 class TestScheme {
 public:
 
@@ -15,20 +17,20 @@ public:
 	//----------------------------------------------------------------------------------
 	//   STANDARD TESTS
 	//----------------------------------------------------------------------------------
-	
+
 
 	static void testEncrypt(long logq, long logp, long logn);
-	
+
 	static void testEncryptBySk(long logq, long logp, long logn);
-	
+
 	static void testDecryptForShare(long logq, long logp, long logn, long logErrorBound);
-	
+
 	static void testEncryptSingle(long logq, long logp);
-	
+
 	static void testAdd(long logq, long logp, long logn);
-	
+
 	static void testMult(long logq, long logp, long logn);
-	
+
 	static void testiMult(long logq, long logp, long logn);
 
 
@@ -73,15 +75,16 @@ public:
 	//----------------------------------------------------------------------------------
 	//   BOOTSTRAPPING TESTS
 	//----------------------------------------------------------------------------------
-    
+
 
 	static void testBootstrap(long logq, long logp, long logn, long logT);
 
 	static void testBootstrapSingleReal(long logq, long logp, long logT);
-    
+
     static void testWriteAndRead(long logq, long logp, long logn);
 
-    
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/TestScheme.h
+++ b/HEAAN/src/TestScheme.h
@@ -81,7 +81,7 @@ public:
 
 	static void testBootstrapSingleReal(long logq, long logp, long logT);
 
-    static void testWriteAndRead(long logq, long logp, long logn);
+	static void testWriteAndRead(long logq, long logp, long logn);
 
 };
 

--- a/HEAAN/src/TimeUtils.cpp
+++ b/HEAAN/src/TimeUtils.cpp
@@ -12,6 +12,8 @@
 
 using namespace std;
 
+namespace heaan {
+
 TimeUtils::TimeUtils() {
 	timeElapsed = 0;
 }
@@ -30,3 +32,4 @@ void TimeUtils::stop(string msg) {
 	cout << "------------------" << endl;
 }
 
+}  // namespace heaan

--- a/HEAAN/src/TimeUtils.h
+++ b/HEAAN/src/TimeUtils.h
@@ -14,6 +14,8 @@ struct timeval;
 
 using namespace std;
 
+namespace heaan {
+
 class TimeUtils {
 public:
 
@@ -27,5 +29,7 @@ public:
 	void stop(string msg);
 
 };
+
+}  // namespace heaan
 
 #endif

--- a/HEAAN/src/TimeUtils.h
+++ b/HEAAN/src/TimeUtils.h
@@ -12,8 +12,6 @@
 
 struct timeval;
 
-using namespace std;
-
 namespace heaan {
 
 class TimeUtils {
@@ -24,9 +22,9 @@ public:
 
 	TimeUtils();
 
-	void start(string msg);
+	void start(std::string msg);
 
-	void stop(string msg);
+	void stop(std::string msg);
 
 };
 


### PR DESCRIPTION
Changes in this pull request resolve the following issues:

- C++ libraries [should be wrapped in a namespace](https://google.github.io/styleguide/cppguide.html#Namespaces) to avoid name conflicts with code that uses them. The entire project is wrapped into the `heaan` namespace.
- [Header files should not use `using` directives](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf7-dont-write-using-namespace-at-global-scope-in-a-header-file) as this pollutes the namespace of source files that include those header files. The `using` directives are removed from all header files and moved to implementation (`.cpp`) files.
- Some trailing whitespace removed.
- A file should `#include` all headers it uses, even when some other already-included header file includes it. This is the reason for the extra `#include <string>` in some places.
- `test.cpp` is modified to work with the new namespace. This is done by adding the appropriate `using` directives.
- Since most of the repo is tab-indented, occurrences of four spaces are changed to a tab.